### PR TITLE
fix[AutoSuggest]: update AbstractPopover styles

### DIFF
--- a/packages/auto-suggest/index.cssx.styl
+++ b/packages/auto-suggest/index.cssx.styl
@@ -6,7 +6,6 @@
   right 0
   bottom 0
 
-
 .loaderCase
   justify-content center
   align-items center
@@ -18,7 +17,6 @@
 .content
   width 100%
   height 100%
-  background-color var(--color-bg-main)
 
 .contentCase
   border-radius 1u
@@ -28,3 +26,9 @@
 
 .selectMenu
   background-color var(--AutoSuggest-itemBg)
+
+.attachment
+  background-color var(--color-bg-main-strong)
+  radius()
+  shadow(3)
+  overflow hidden

--- a/packages/auto-suggest/index.tsx
+++ b/packages/auto-suggest/index.tsx
@@ -229,7 +229,7 @@ function AutoSuggest ({
       testID=testID
     )
 
-    AbstractPopover(
+    AbstractPopover.attachment(
       visible=(isShow || isLoading)
       anchorRef=inputRef
       matchAnchorWidth=matchAnchorWidth


### PR DESCRIPTION
New:
<img width="483" height="335" alt="Screenshot 2026-02-06 at 14 44 32" src="https://github.com/user-attachments/assets/fa153aa6-78f9-4d2e-8121-13f69fc73b22" />

Old:
<img width="500" height="346" alt="Screenshot 2026-02-06 at 14 46 14" src="https://github.com/user-attachments/assets/7b614c41-e28f-4682-b39f-e4f052fe28f7" />
