### PR TITLE
[codex] Move file picker packages to peers

### DIFF
--- a/packages/file-input/package.json
+++ b/packages/file-input/package.json
@@ -26,13 +26,13 @@
     "@startupjs-ui/dialogs": "^0.3.1",
     "@startupjs-ui/div": "^0.3.1",
     "busboy": "^1.6.0",
-    "expo-document-picker": ">=14.0.0",
-    "expo-image-picker": ">=17.0.0",
     "sharp": "^0.34.5"
   },
   "peerDependencies": {
     "@aws-sdk/client-s3": "*",
     "@azure/storage-blob": "*",
+    "expo-document-picker": "*",
+    "expo-image-picker": "*",
     "mongodb": "*",
     "react": "*",
     "react-native": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6585,12 +6585,12 @@ __metadata:
     "@startupjs-ui/dialogs": "npm:^0.3.1"
     "@startupjs-ui/div": "npm:^0.3.1"
     busboy: "npm:^1.6.0"
-    expo-document-picker: "npm:>=14.0.0"
-    expo-image-picker: "npm:>=17.0.0"
     sharp: "npm:^0.34.5"
   peerDependencies:
     "@aws-sdk/client-s3": "*"
     "@azure/storage-blob": "*"
+    expo-document-picker: "*"
+    expo-image-picker: "*"
     mongodb: "*"
     react: "*"
     react-native: "*"
@@ -12887,7 +12887,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-document-picker@npm:>=14.0.0, expo-document-picker@npm:~55.0.11":
+"expo-document-picker@npm:~55.0.11":
   version: 55.0.11
   resolution: "expo-document-picker@npm:55.0.11"
   peerDependencies:
@@ -12948,7 +12948,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-image-picker@npm:>=17.0.0, expo-image-picker@npm:~55.0.16":
+"expo-image-picker@npm:~55.0.16":
   version: 55.0.16
   resolution: "expo-image-picker@npm:55.0.16"
   dependencies:


### PR DESCRIPTION
## Summary
- Move `expo-document-picker` and `expo-image-picker` from `@startupjs-ui/file-input` dependencies to peer dependencies.
- Keep both picker peer ranges as `*` so consuming apps provide the installed Expo-compatible versions.
- Refresh `yarn.lock` after the manifest change.

## Validation
- `yarn install`
- pre-commit hook: `yarn generate-package-dts`
- pre-commit hook: `node scripts/check-startupjs-ui-exports.mjs`
- manifest assertion that both picker packages are peer deps and absent from dependencies
