### PR TITLE
fix(file-input): handle upload stream errors instead of crashing the server

### DIFF
--- a/packages/file-input/files.plugin.js
+++ b/packages/file-input/files.plugin.js
@@ -233,6 +233,20 @@ export default createPlugin({
             mimeType = 'image/jpeg'
           }
 
+          // Surface stream errors (e.g. sharp failing to decode a corrupt or
+          // forged "image/*" upload) as a 400 instead of letting an unhandled
+          // 'error' event crash the whole server process. This is essential for
+          // public/untrusted uploads, where a single garbage payload with an
+          // image mime type would otherwise take the server down. Attach to the
+          // source busboy stream and, for images, the sharp stream too — an
+          // unhandled 'error' on either is fatal.
+          const onStreamError = err => {
+            console.error('[StartupJS Files] Upload stream error:', err)
+            if (!res.headersSent) res.status(400).send('Invalid file data')
+          }
+          file.on('error', onStreamError)
+          if (stream !== file) stream.on('error', onStreamError)
+
           // Regardless of whether it's an image or not, collect the data
           stream.on('data', data => buffers.push(data))
 


### PR DESCRIPTION
## Problem

The single-file upload route (`UPLOAD_SINGLE_FILE_URL`) pipes image uploads through `sharp` for resizing/conversion, but never attaches an `'error'` listener to the resulting stream:

```js
if (mimeType.startsWith('image/')) {
  stream = file.pipe(sharp().rotate().resize(...).toFormat('jpeg', ...))
  ...
}
stream.on('data', ...)   // no 'error' handler
stream.on('end', ...)
```

When `sharp` fails to decode the bytes — a corrupt file, or a **forged upload that declares an `image/*` mime type but carries garbage** — the stream emits `'error'` with no listener. Node treats an unhandled stream `'error'` as an uncaught exception, so **the entire server process crashes**.

For any app that allows **public or otherwise untrusted uploads**, this is a trivial denial-of-service: one malformed payload takes the server down. (Found while enabling public visitor uploads in a CMS built on startupjs — an E2E "server survives a bad upload" test caught it.)

## Fix

Attach an error handler that responds `400 Invalid file data` instead of crashing. It is wired to **both** the source busboy stream and (for images) the `sharp` transform stream, since an unhandled `'error'` on either is fatal, and guards on `res.headersSent` so it never double-responds.

```js
const onStreamError = err => {
  console.error('[StartupJS Files] Upload stream error:', err)
  if (!res.headersSent) res.status(400).send('Invalid file data')
}
file.on('error', onStreamError)
if (stream !== file) stream.on('error', onStreamError)
```

## Reproduce

With the files plugin enabled, `POST` a few bytes of non-image data to the upload endpoint with header `Content-Type: image/png` (multipart). Before: the node process exits. After: `400 Invalid file data`, server stays up.

## Notes / scope

- No public API change. Upload **policy** (who may upload, allowed mime types, size caps) is already expressible via the existing `canUpload` server hook, so this PR is intentionally limited to the crash fix.
- Possible follow-up (happy to add if you'd like it in this release): a first-class `maxUploadBytes` server option enforced **during** streaming (early-abort `413`), so untrusted uploads can't buffer unbounded memory before the `canUpload` check runs on the full blob. Left out here to keep the fix focused.
