### PR TITLE
feat(div, span): supportTextNodes auto-wrap on Div + pure mode on Span

### DIFF
--- a/packages/div/index.d.ts
+++ b/packages/div/index.d.ts
@@ -19,6 +19,13 @@ export interface DivProps extends Omit<ViewProps, 'role'> {
     style?: StyleProp<ViewStyle>;
     /** Content rendered inside Div */
     children?: ReactNode;
+    /** Auto-wrap bare text children. When true, runs of consecutive string/number
+     * children (including those inside arrays/fragments) are each wrapped into a
+     * single text node so they render correctly in a non-text container. @default false */
+    supportTextNodes?: boolean;
+    /** How to render an auto-wrapped text run (only used with supportTextNodes).
+     * Receives the merged text; should return a text element. Defaults to <Span/>. */
+    renderTextNode?: (text: string) => ReactNode;
     /** Visual feedback variant @default 'opacity' */
     variant?: 'opacity' | 'highlight';
     /** Render children in a horizontal row */

--- a/packages/div/index.tsx
+++ b/packages/div/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useLayoutEffect, useMemo, useState, useRef, type ReactNode, type RefObject } from 'react'
+import { Children, cloneElement, createElement, Fragment, isValidElement, useContext, useLayoutEffect, useMemo, useState, useRef, type ReactNode, type RefObject } from 'react'
 import {
   View,
   Pressable,
@@ -17,6 +17,7 @@ import {
   mergeInheritedTextStyles,
   omitInheritedTextStyle
 } from '@startupjs-ui/span/textStyleContext'
+import Span from '@startupjs-ui/span'
 import { useDecorateTooltipProps } from './useTooltip'
 import STYLES from './index.cssx.styl'
 
@@ -51,6 +52,13 @@ export interface DivProps extends Omit<ViewProps, 'role'> {
   style?: StyleProp<ViewStyle>
   /** Content rendered inside Div */
   children?: ReactNode
+  /** Auto-wrap bare text children. When true, runs of consecutive string/number
+   * children (including those inside arrays/fragments) are each wrapped into a
+   * single text node so they render correctly in a non-text container. @default false */
+  supportTextNodes?: boolean
+  /** How to render an auto-wrapped text run (only used with supportTextNodes).
+   * Receives the merged text; should return a text element. Defaults to <Span/>. */
+  renderTextNode?: (text: string) => ReactNode
   /** Visual feedback variant @default 'opacity' */
   variant?: 'opacity' | 'highlight'
   /** Render children in a horizontal row */
@@ -106,6 +114,8 @@ export interface DivProps extends Omit<ViewProps, 'role'> {
 function Div ({
   style: rawStyle = [],
   children,
+  supportTextNodes = false,
+  renderTextNode,
   variant = 'opacity',
   row,
   wrap,
@@ -131,6 +141,7 @@ function Div ({
   ...props
 }: DivProps): ReactNode {
   assertDeprecatedValues({ pushed, renderTooltip })
+  const renderedChildren = supportTextNodes ? wrapTextChildren(children, renderTextNode) : children
   let style = StyleSheet.flatten(rawStyle) as ViewStyle | undefined
   // on RN row-reverse switches margins and paddings sides, so we switch them back
   if (isNative && reverse) style = reverseMarginPaddingSides(style)
@@ -230,7 +241,7 @@ function Div ({
       ]
       accessible=accessible
       ...renderProps
-    )= children
+    )= renderedChildren
   `
   const styledDivElement = nextInheritedTextStyle
     ? pug`
@@ -245,6 +256,35 @@ function Div ({
       = tooltipElement
     `
   } else return styledDivElement
+}
+
+// Auto-wrap bare text so it renders in a non-text container. Each maximal run of
+// consecutive string/number children is merged into one text node (so 'a {x} b'
+// becomes one line, not three stacked nodes); element children break a run;
+// fragments are traversed inline; arrays are already flattened by React.Children.
+function wrapTextChildren (children: ReactNode, renderTextNode?: (text: string) => ReactNode): ReactNode {
+  const out: ReactNode[] = []
+  let run = ''
+  let key = 0
+  const flush = () => {
+    if (run === '') return
+    const text = run
+    run = ''
+    const node = renderTextNode ? renderTextNode(text) : createElement(Span, null, text)
+    out.push(isValidElement(node) ? cloneElement(node, { key: `__t${key++}` }) : node)
+  }
+  const walk = (nodes: ReactNode) => {
+    Children.forEach(nodes, child => {
+      if (child == null || typeof child === 'boolean') return
+      if (typeof child === 'string' || typeof child === 'number') { run += String(child); return }
+      if (isValidElement(child) && child.type === Fragment) { walk((child.props as { children?: ReactNode }).children); return }
+      flush()
+      out.push(isValidElement(child) && child.key == null ? cloneElement(child, { key: `__e${key++}` }) : child)
+    })
+  }
+  walk(children)
+  flush()
+  return out
 }
 
 function isWebOnlyRole (role: unknown): role is Exclude<UIRole, ViewProps['role']> {

--- a/packages/span/index.d.ts
+++ b/packages/span/index.d.ts
@@ -22,6 +22,10 @@ export interface SpanProps extends TextProps {
     full?: boolean;
     /** description text color */
     description?: boolean;
+    /** Omit the default root typography (font size/family/weight and base color)
+     * while still applying inherited text styles and animation handling. Useful
+     * when the surrounding stylesheet fully controls typography. @default false */
+    pure?: boolean;
     /** theme name */
     theme?: string;
     /** h1 header */

--- a/packages/span/index.tsx
+++ b/packages/span/index.tsx
@@ -28,6 +28,10 @@ export interface SpanProps extends TextProps {
   full?: boolean
   /** description text color */
   description?: boolean
+  /** Omit the default root typography (font size/family/weight and base color)
+   * while still applying inherited text styles and animation handling. Useful
+   * when the surrounding stylesheet fully controls typography. @default false */
+  pure?: boolean
   /** theme name */
   theme?: string
   /** h1 header */
@@ -55,6 +59,7 @@ function Span ({
   italic,
   full,
   description,
+  pure,
   theme,
   h1,
   h2,
@@ -91,10 +96,11 @@ function Span ({
   const Component = hasAnimatedProperty(style) ? Animated.Text : Text
 
   const spanElement = pug`
-    Component.root(
+    Component(
       ref=ref
       style=style
       styleName=[
+        pure ? undefined : 'root',
         theme,
         variant,
         tag,


### PR DESCRIPTION
Two small, opt-in, backward-compatible additions to the base building blocks.

## Div — `supportTextNodes` + `renderTextNode`
`<Div supportTextNodes>` lets you put bare text directly inside a Div (a non-text container) without manually wrapping every string in a `<Span>`:

- Each maximal run of consecutive `string`/`number` children is merged into a single text node, so `Total: {n} items` renders as one inline node instead of three stacked ones.
- Element children break a run; fragments are traversed inline; arrays are already flattened by `React.Children`.
- `renderTextNode(text)` optionally customizes how a wrapped run renders (defaults to `<Span>`), so a design system can route auto-wrapped text through its own text component.

Both default off — existing usage is unchanged.

## Span — `pure`
`<Span pure>` omits the default root typography (font size/family/weight and base color) while keeping inherited text styles, line-height resolution, and animation handling. Useful when the surrounding stylesheet fully owns typography and the component-level defaults would otherwise get in the way. Defaults off.