### PR TITLE
Add LMS wrapper compatibility knobs

### DIFF
--- a/packages/breadcrumbs/index.cssx.styl
+++ b/packages/breadcrumbs/index.cssx.styl
@@ -1,3 +1,13 @@
+// ----- CONFIG: $UI.Breadcrumbs
+
+$this = merge({
+  currentColor: 'text-secondary',
+  linkColor: 'text-description',
+  separatorColor: 'text-description'
+}, $UI.Breadcrumbs, true)
+
+// ----- COMPONENT
+
 _iconMargin = 0.5u
 
 .iconWrapper
@@ -51,3 +61,8 @@ _iconMargin = 0.5u
 
   &.xxl
     font(h4)
+
+// ----- JS EXPORTS
+
+:export
+  config: $this

--- a/packages/breadcrumbs/index.d.ts
+++ b/packages/breadcrumbs/index.d.ts
@@ -3,7 +3,6 @@
 
 import React, { type ReactNode } from 'react';
 import { type StyleProp, type ViewStyle } from 'react-native';
-import './index.cssx.styl';
 type BreadcrumbsSize = 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl';
 declare const _default: React.ComponentType<BreadcrumbsProps>;
 export default _default;

--- a/packages/breadcrumbs/index.tsx
+++ b/packages/breadcrumbs/index.tsx
@@ -6,7 +6,15 @@ import Div from '@startupjs-ui/div'
 import Icon from '@startupjs-ui/icon'
 import Link from '@startupjs-ui/link'
 import Span from '@startupjs-ui/span'
-import './index.cssx.styl'
+import STYLES from './index.cssx.styl'
+
+const {
+  config: {
+    currentColor,
+    linkColor,
+    separatorColor
+  }
+} = STYLES
 
 type BreadcrumbsSize = 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl'
 
@@ -57,6 +65,10 @@ function Breadcrumbs ({
     )
   }
   const getColor = useColors()
+  const resolveColor = (color: string): string => getColor(color) || color
+  const resolvedCurrentColor = resolveColor(currentColor)
+  const resolvedLinkColor = resolveColor(linkColor)
+  const resolvedSeparatorColor = resolveColor(separatorColor)
 
   function renderItem ({
     icon,
@@ -90,16 +102,16 @@ function Breadcrumbs ({
         - const isLastRoute = index === routes.length - 1
         React.Fragment(key=index)
           if isLastRoute
-            = renderItem({ icon, color: getColor('text-secondary'), bold: true, children: name })
+            = renderItem({ icon, color: resolvedCurrentColor, bold: true, children: name })
           else
             Div.item(row)
               Link(
                 replace=replace
                 to=to
               )
-                = renderItem({ icon, color: getColor('text-description'), children: name })
+                = renderItem({ icon, color: resolvedLinkColor, children: name })
               if typeof separator === 'string'
-                Span.separator(styleName=[size])
+                Span.separator(style={ color: resolvedSeparatorColor } styleName=[size])
                   | &nbsp#{separator}&nbsp
               else
                 = separator

--- a/packages/link/index.cssx.styl
+++ b/packages/link/index.cssx.styl
@@ -1,12 +1,26 @@
+// ----- CONFIG: $UI.Link
+
+$this = merge({
+  color: 'default',
+  textDecorationColor: null
+}, $UI.Link, true)
+
+// ----- COMPONENT
+
 .root
   color: var(--color-text-secondary)
   text-decoration-line underline
-  text-decoration-color @color
+  text-decoration-color: $this.textDecorationColor ? $this.textDecorationColor : @color
 
   &.primary
     color var(--color-text-primary)
-    text-decoration-color @color
+    text-decoration-color: $this.textDecorationColor ? $this.textDecorationColor : @color
 
   &.block
     display flex
     text-decoration none
+
+// ----- JS EXPORTS
+
+:export
+  config: $this

--- a/packages/link/index.d.ts
+++ b/packages/link/index.d.ts
@@ -4,7 +4,6 @@
 import { type ReactNode } from 'react';
 import { type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
 import { type DivProps } from '@startupjs-ui/div';
-import './index.cssx.styl';
 declare const _default: import("react").ComponentType<LinkProps>;
 export default _default;
 export declare const _PropsJsonSchema: {};

--- a/packages/link/index.tsx
+++ b/packages/link/index.tsx
@@ -6,10 +6,15 @@ import { themed } from '@startupjs-ui/core'
 import Button from '@startupjs-ui/button'
 import Div, { type DivProps } from '@startupjs-ui/div'
 import Span from '@startupjs-ui/span'
-import './index.cssx.styl'
+import STYLES from './index.cssx.styl'
 
 const isWeb = Platform.OS === 'web'
 const EXTERNAL_LINK_REGEXP = /^(https?:\/\/|\/\/|mailto:)/i
+const {
+  config: {
+    color: defaultColor
+  }
+} = STYLES
 
 export default observer(themed('Link', Link))
 
@@ -45,7 +50,7 @@ function Link ({
   style,
   to,
   href,
-  color = 'default',
+  color = defaultColor,
   theme,
   display,
   push,

--- a/packages/number-input/index.cssx.styl
+++ b/packages/number-input/index.cssx.styl
@@ -1,7 +1,14 @@
+// ----- CONFIG: $UI.NumberInput
+
+$this = merge({
+  buttonBorderColor: var(--color-border-main)
+}, $UI.NumberInput, true)
+
+// ----- COMPONENT
+
 $sizes = 'l' 'm' 's'
 // border color should be taken from text input config
 // because the input border and the button border overlap each other
-$inputBorderColor = var(--color-border-main)
 $padding = {
   l: 6u,
   m: 5u,
@@ -53,7 +60,7 @@ $padding = {
 
 .input-button
   position absolute
-  border-color $inputBorderColor
+  border-color $this.buttonBorderColor
 
   &.vertical
     right 0
@@ -85,3 +92,8 @@ $padding = {
       left 0
       border-top-right-radius 0
       border-bottom-right-radius 0
+
+// ----- JS EXPORTS
+
+:export
+  config: $this

--- a/packages/popover/README.mdx
+++ b/packages/popover/README.mdx
@@ -13,7 +13,7 @@ A floating panel that appears near an anchor element when triggered. Use it to d
 
 The `visible` prop controls whether the popover is shown, and `onChange` is called when visibility should change. You can also use `$visible` for two-way data binding. Pass `children` as the anchor (the always-visible element) and `renderContent` to render the popover content. A `ref` can be used to programmatically call `open()` and `close()`.
 
-The component also supports lifecycle callbacks inherited from AbstractPopover: `onRequestOpen`, `onRequestClose`, `onOpenComplete`, and `onCloseComplete`. Use `renderWrapper` to wrap the popover node with custom markup.
+The component also supports lifecycle callbacks inherited from AbstractPopover: `onRequestOpen`, `onRequestClose`, `onOpenComplete`, and `onCloseComplete`. Use `onDismiss` when you need to react after the popover finishes closing. Use `renderWrapper` to wrap the popover node with custom markup.
 
 ```jsx
 import { Popover } from 'startupjs-ui'

--- a/packages/popover/index.d.ts
+++ b/packages/popover/index.d.ts
@@ -21,6 +21,8 @@ export interface PopoverProps extends Omit<AbstractPopoverProps, 'anchorRef' | '
     $visible?: any;
     /** Called when visibility should change */
     onChange?: (visible: boolean) => void;
+    /** Called when popover finishes closing */
+    onDismiss?: () => void;
     /** Open the popover when the anchor wrapper is pressed @default true */
     openOnAnchorPress?: boolean;
     /** Anchor content */

--- a/packages/popover/index.tsx
+++ b/packages/popover/index.tsx
@@ -23,6 +23,8 @@ export interface PopoverProps extends Omit<AbstractPopoverProps, 'anchorRef' | '
   $visible?: any
   /** Called when visibility should change */
   onChange?: (visible: boolean) => void
+  /** Called when popover finishes closing */
+  onDismiss?: () => void
   /** Open the popover when the anchor wrapper is pressed @default true */
   openOnAnchorPress?: boolean
   /** Anchor content */
@@ -46,6 +48,8 @@ function Popover ({
   children,
   renderContent,
   onChange,
+  onCloseComplete,
+  onDismiss,
   openOnAnchorPress = true,
   renderWrapper,
   overlayStyle,
@@ -86,6 +90,10 @@ function Popover ({
 
   const setVisibleTrue = useCallback(() => { handleChange(true) }, [handleChange])
   const setVisibleFalse = useCallback(() => { handleChange(false) }, [handleChange])
+  const handleCloseComplete = useCallback((...args: any[]) => {
+    onCloseComplete?.(...args)
+    onDismiss?.()
+  }, [onCloseComplete, onDismiss])
 
   const renderOverlayWrapper = (node: ReactNode): ReactNode => {
     const wrappedNode = renderWrapper ? renderWrapper(node) : node
@@ -101,7 +109,7 @@ function Popover ({
     Div(
       style=style
       ref=anchorRef
-      onPress=!isUncontrolled && openOnAnchorPress ? setVisibleTrue : null
+      onPress=openOnAnchorPress ? setVisibleTrue : null
     )= children
     AbstractPopover.attachment(
       ...props
@@ -109,6 +117,7 @@ function Popover ({
       style=[attachmentStyle]
       anchorRef=anchorRef
       renderWrapper=renderOverlayWrapper
+      onCloseComplete=handleCloseComplete
     )= renderContent && renderContent()
   `
 }

--- a/packages/popover/index.tsx
+++ b/packages/popover/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useCallback, useImperativeHandle, type ReactNode, type RefObject } from 'react'
+import { Children, isValidElement, useMemo, useRef, useCallback, useImperativeHandle, type ReactNode, type RefObject } from 'react'
 import { View, TouchableWithoutFeedback, type StyleProp, type ViewStyle } from 'react-native'
 import { pug, observer, useBind, $ } from 'startupjs'
 import { themed } from '@startupjs-ui/core'
@@ -94,6 +94,17 @@ function Popover ({
     onCloseComplete?.(...args)
     onDismiss?.()
   }, [onCloseComplete, onDismiss])
+  const shouldOpenOnAnchorPress = useMemo(() => {
+    if (!openOnAnchorPress) return false
+
+    const childArray = Children.toArray(children)
+    if (childArray.length !== 1) return true
+
+    const child = childArray[0]
+    if (!isValidElement<{ onPress?: unknown }>(child)) return true
+
+    return typeof child.props.onPress !== 'function'
+  }, [children, openOnAnchorPress])
 
   const renderOverlayWrapper = (node: ReactNode): ReactNode => {
     const wrappedNode = renderWrapper ? renderWrapper(node) : node
@@ -109,7 +120,7 @@ function Popover ({
     Div(
       style=style
       ref=anchorRef
-      onPress=openOnAnchorPress ? setVisibleTrue : null
+      onPress=shouldOpenOnAnchorPress ? setVisibleTrue : null
     )= children
     AbstractPopover.attachment(
       ...props

--- a/packages/select/index.cssx.styl
+++ b/packages/select/index.cssx.styl
@@ -1,0 +1,11 @@
+// ----- CONFIG: $UI.Select
+
+$this = merge({
+  emptyValueLabel: null,
+  multiline: 0
+}, $UI.Select, true)
+
+// ----- JS EXPORTS
+
+:export
+  config: $this

--- a/packages/select/index.tsx
+++ b/packages/select/index.tsx
@@ -4,6 +4,18 @@ import TextInput, { type UITextInputProps } from '@startupjs-ui/text-input'
 import { faAngleDown } from '@fortawesome/free-solid-svg-icons/faAngleDown'
 import Wrapper from './Wrapper'
 import { getLabelFromValue, type SelectOption } from './Wrapper/helpers'
+import STYLES from './index.cssx.styl'
+
+const {
+  config: {
+    emptyValueLabel: defaultEmptyValueLabel,
+    multiline: defaultMultiline
+  }
+} = STYLES
+
+function isConfigEnabled (value: unknown): boolean {
+  return value !== false && value !== 0 && value !== '0'
+}
 
 export default observer(Select)
 
@@ -56,8 +68,12 @@ function Select ({
   'aria-required': ariaRequired,
   onChange,
   ref,
+  multiline,
   ...props
 }: SelectProps): ReactNode {
+  const resolvedEmptyValueLabel = emptyValueLabel ?? defaultEmptyValueLabel ?? undefined
+  const resolvedMultiline = multiline ?? isConfigEnabled(defaultMultiline)
+
   function renderWrapper (
     { style }: { style?: any },
     children: ReactNode
@@ -70,7 +86,7 @@ function Select ({
         value=value
         onChange=onChange
         showEmptyValue=showEmptyValue
-        emptyValueLabel=emptyValueLabel
+        emptyValueLabel=resolvedEmptyValueLabel
         testID=testID
         aria-label=ariaLabel
         id=id
@@ -88,12 +104,13 @@ function Select ({
     //- Add onKeyPress to 'keyDown' key that opens select dropdown
     TextInput(
       ref=ref
-      value=getLabelFromValue(value, options, emptyValueLabel)
+      value=getLabelFromValue(value, options, resolvedEmptyValueLabel)
       disabled=disabled
       icon=faAngleDown
       iconPosition='right'
       _renderWrapper=renderWrapper
       editable=false /* HACK: Fixes cursor visibility when focusing on Select because we're focusing on TextInput */
+      multiline=resolvedMultiline
       ...props
     )
   `


### PR DESCRIPTION
## Summary
- add non-breaking theme/config knobs for Link default color and underline color
- add Breadcrumbs color knobs, NumberInput button border color knob, and Select default empty label/multiline knobs
- add Popover onDismiss support and guarded uncontrolled-anchor opening without duplicate accessible button roles

## LMS migration context
These knobs allow LMS to remove local facade wrappers for Link, Breadcrumbs, NumberInput, Select, and Popover after a new startupjs-ui release is published and installed.

## Verification
- yarn generate-package-dts
- node scripts/check-startupjs-ui-exports.mjs
- npx eslint packages/link packages/select packages/breadcrumbs packages/number-input packages/popover
- yarn workspace startupjs-ui-storybook test-storybook stories/dropdown.stories.tsx
- yarn storybook:test
- git diff --check

CI: storybook-tests passed on PR #37.