### PR TITLE
fix(div): support row alignment values

### DIFF
--- a/packages/div/README.mdx
+++ b/packages/div/README.mdx
@@ -54,8 +54,8 @@ You can use the following props to manage layout:
 - `row` -- aligns children from left to right (default: `false`)
 - `reverse` -- reverses the children order depending on the direction (default: `false`)
 - `wrap` -- controls wrapping of children into multiple rows (default: `false`)
-- `align` -- controls horizontal alignment (values: `'left'`, `'center'`, `'right'`)
-- `vAlign` -- controls vertical alignment (values: `'top'`, `'center'`, `'bottom'`)
+- `align` -- controls horizontal alignment (values: `'left'`, `'center'`, `'right'`; row layouts also support `'around'` and `'between'`)
+- `vAlign` -- controls vertical alignment (values: `'top'`, `'center'`, `'bottom'`; row layouts also support `'stretch'`, `'start'`, and `'end'`)
 - `gap` -- defines the spacing between items in [units](/docs/tutorial/TricksWithStyles#units); passing `true` is equivalent to `2`
 
 ```jsx example

--- a/packages/div/index.cssx.styl
+++ b/packages/div/index.cssx.styl
@@ -51,14 +51,29 @@ _shadowLevels = ('1' '2' '3' '4')
     &.right
       justify-content flex-end
 
+    &.between
+      justify-content space-between
+
+    &.around
+      justify-content space-around
+
+    &.v_start
+      align-items flex-start
+
     &.v_top
       align-items flex-start
 
     &.v_center
       align-items center
 
+    &.v_end
+      align-items flex-end
+
     &.v_bottom
       align-items flex-end
+
+    &.v_stretch
+      align-items stretch
 
   &.wrap
     flex-wrap wrap

--- a/packages/div/index.d.ts
+++ b/packages/div/index.d.ts
@@ -34,10 +34,10 @@ export interface DivProps extends Omit<ViewProps, 'role'> {
     wrap?: boolean;
     /** Reverse children order for row layouts */
     reverse?: boolean;
-    /** Horizontal alignment when using row/column */
-    align?: 'left' | 'center' | 'right';
-    /** Vertical alignment when using row/column */
-    vAlign?: 'top' | 'center' | 'bottom';
+    /** Horizontal alignment when using row/column. Row also supports Row-compatible distribution values. */
+    align?: 'left' | 'center' | 'right' | 'around' | 'between';
+    /** Vertical alignment when using row/column. Row also supports Row-compatible cross-axis values. */
+    vAlign?: 'top' | 'center' | 'bottom' | 'stretch' | 'start' | 'end';
     /** Spacing between children (true maps to default gap) */
     gap?: boolean | number;
     /** Enable press feedback styles (hover and active states) @default true */

--- a/packages/div/index.tsx
+++ b/packages/div/index.tsx
@@ -67,10 +67,10 @@ export interface DivProps extends Omit<ViewProps, 'role'> {
   wrap?: boolean
   /** Reverse children order for row layouts */
   reverse?: boolean
-  /** Horizontal alignment when using row/column */
-  align?: 'left' | 'center' | 'right'
-  /** Vertical alignment when using row/column */
-  vAlign?: 'top' | 'center' | 'bottom'
+  /** Horizontal alignment when using row/column. Row also supports Row-compatible distribution values. */
+  align?: 'left' | 'center' | 'right' | 'around' | 'between'
+  /** Vertical alignment when using row/column. Row also supports Row-compatible cross-axis values. */
+  vAlign?: 'top' | 'center' | 'bottom' | 'stretch' | 'start' | 'end'
   /** Spacing between children (true maps to default gap) */
   gap?: boolean | number
   /** Enable press feedback styles (hover and active states) @default true */


### PR DESCRIPTION
## Summary
- add Row-compatible alignment values to Div row layouts: align='between'/'around'
- add Row-compatible cross-axis values for row layouts: vAlign='start'/'end'/'stretch'
- update Div docs and generated declarations

## Why
The package already deprecates Row with "use <Div row>", and existing package docs use <Div row align='between'> / <Div row align='around'>. The Div implementation and types only supported left/center/right, so these documented Row-compatible layouts did not actually work without inline styles.

## Verification
- yarn generate-package-dts
- yarn eslint packages/div/index.tsx
- node scripts/check-startupjs-ui-exports.mjs
- git diff --check
