### PR TITLE
Expose u and support confirm labels

### DIFF
--- a/packages/dialogs/README.helpers.js
+++ b/packages/dialogs/README.helpers.js
@@ -39,11 +39,11 @@ export function AlertSandbox ({ title, message }) {
   `
 }
 
-export function ConfirmSandbox ({ title, message }) {
+export function ConfirmSandbox ({ title, message, cancelLabel, confirmLabel }) {
   const [pressedButtonText, setPressedButtonText] = useState()
 
   async function onPress () {
-    const isConfirmed = await confirm({ title, message })
+    const isConfirmed = await confirm({ title, message, cancelLabel, confirmLabel })
     setPressedButtonText(isConfirmed ? 'OK' : 'Cancel')
   }
 

--- a/packages/dialogs/README.mdx
+++ b/packages/dialogs/README.mdx
@@ -71,10 +71,11 @@ return pug`
 
 Asks the user to confirm or cancel an action. The dialog shows `Cancel` and `OK` buttons. Returns `true` if the user clicks `OK`, or `false` if they click `Cancel`.
 
-You can pass either a plain string or an options object with `title` and `message`.
+You can pass either a plain string or an options object with `title`, `message`,
+`cancelLabel`, and `confirmLabel`.
 
 ```js
-const result = await confirm(message | { title?, message })
+const result = await confirm(message | { title?, message, cancelLabel?, confirmLabel? })
 ```
 
 ```jsx example
@@ -140,7 +141,7 @@ return pug`
 
 <Sandbox
   Component={ConfirmSandbox}
-  props={{ title: 'Confirm', message: 'Press a button' }}
+  props={{ title: 'Confirm', message: 'Press a button', cancelLabel: 'Cancel', confirmLabel: 'OK' }}
   propsJsonSchema={ConfirmOptionsPropsJsonSchema}
 />
 

--- a/packages/dialogs/confirm.tsx
+++ b/packages/dialogs/confirm.tsx
@@ -7,17 +7,25 @@ export interface ConfirmOptions {
   title?: string
   /** The message displayed inside the dialog */
   message: string
+  /** Label for the cancel button */
+  cancelLabel?: string
+  /** Label for the confirm button */
+  confirmLabel?: string
 }
 
 export default async function confirm (options: string | ConfirmOptions): Promise<boolean> {
   let title: unknown
   let message: unknown
+  let cancelLabel: unknown
+  let confirmLabel: unknown
 
   if (typeof options === 'string') {
     message = options
   } else if (options && typeof options === 'object') {
     title = (options as any).title
     message = (options as any).message
+    cancelLabel = (options as any).cancelLabel
+    confirmLabel = (options as any).confirmLabel
   }
 
   if (title != null && typeof title !== 'string') {
@@ -28,15 +36,25 @@ export default async function confirm (options: string | ConfirmOptions): Promis
     throw new Error('[@startupjs-ui/dialogs] confirm: message should be a string')
   }
 
+  if (cancelLabel != null && typeof cancelLabel !== 'string') {
+    throw new Error('[@startupjs-ui/dialogs] confirm: cancelLabel should be a string')
+  }
+
+  if (confirmLabel != null && typeof confirmLabel !== 'string') {
+    throw new Error('[@startupjs-ui/dialogs] confirm: confirmLabel should be a string')
+  }
+
   const normalizedTitle = typeof title === 'string' ? title : undefined
+  const normalizedCancelLabel = typeof cancelLabel === 'string' ? cancelLabel : 'Cancel'
+  const normalizedConfirmLabel = typeof confirmLabel === 'string' ? confirmLabel : 'OK'
 
   const result = await new Promise<boolean>(resolve => {
     openDialog({
       title: normalizedTitle,
       role: 'alertdialog',
       children: message,
-      cancelLabel: 'Cancel',
-      confirmLabel: 'OK',
+      cancelLabel: normalizedCancelLabel,
+      confirmLabel: normalizedConfirmLabel,
       showCross: false,
       enableBackdropPress: false,
       onCancel: () => { resolve(false) },

--- a/packages/startupjs-ui/exports/u.tsx
+++ b/packages/startupjs-ui/exports/u.tsx
@@ -1,0 +1,1 @@
+export { u as default } from '@startupjs-ui/core'

--- a/packages/startupjs-ui/index.tsx
+++ b/packages/startupjs-ui/index.tsx
@@ -102,6 +102,7 @@ export {
   getCssVariable,
   Palette,
   Colors,
+  u,
   themed,
   ThemeProvider,
   ThemeContext

--- a/packages/startupjs-ui/package.json
+++ b/packages/startupjs-ui/package.json
@@ -100,6 +100,7 @@
     "./Palette": "./exports/Palette.tsx",
     "./palette": "./exports/_palette.tsx",
     "./Colors": "./exports/Colors.tsx",
+    "./u": "./exports/u.tsx",
     "./themed": "./exports/themed.tsx",
     "./ThemeProvider": "./exports/ThemeProvider.tsx",
     "./ThemeContext": "./exports/ThemeContext.tsx",


### PR DESCRIPTION
## Summary
- expose the core `u` helper from `startupjs-ui` root and `startupjs-ui/u`
- allow `confirm({ message, cancelLabel, confirmLabel })` without changing existing string/object calls
- document confirm labels in dialogs docs

## Checks
- `node scripts/check-startupjs-ui-exports.mjs`
- `yarn exec eslint packages/startupjs-ui/index.tsx packages/startupjs-ui/exports/u.tsx packages/dialogs/confirm.tsx packages/dialogs/README.helpers.js`
- `git diff --check HEAD~1..HEAD`