### PR TITLE
feat(startupjs-ui): support router portal provider

### DIFF
--- a/packages/startupjs-ui/README.mdx
+++ b/packages/startupjs-ui/README.mdx
@@ -36,6 +36,7 @@ import styleOverrides from './style.cssx.styl'
   palette={palette}
   colors={colors}
   componentColors={componentColors}
+  routerPortal
 >
   <Stack />
 </StartupjsProvider>
@@ -60,3 +61,4 @@ import styleOverrides from './style.cssx.styl'
 - `palette` -- theme palette overrides.
 - `colors` -- theme color overrides.
 - `componentColors` -- component-level color overrides.
+- `routerPortal` -- when `true`, mounts an additional `Portal.Provider` inside the router tree. Use it when portal content can render router-aware components such as links or navigation actions.

--- a/packages/startupjs-ui/plugin.js
+++ b/packages/startupjs-ui/plugin.js
@@ -2,6 +2,7 @@ import { createElement as el } from 'react'
 import { createPlugin, ROOT_MODULE as MODULE } from 'startupjs/registry'
 import { setCustomInputs } from '@startupjs-ui/input/globalCustomInputs'
 import { setCustomIcons } from '@startupjs-ui/icon/globalCustomIcons'
+import Portal from '@startupjs-ui/portal'
 import UiProvider from './UiProvider'
 
 let hasCustomElementsInitialized = false
@@ -10,7 +11,7 @@ export default createPlugin({
   name: 'ui',
   enabled: true,
   order: 'system ui',
-  client: (props) => ({
+  client: ({ routerPortal = false, ...props } = {}) => ({
     renderRoot ({ children }) {
       if (!hasCustomElementsInitialized) {
         hasCustomElementsInitialized = true
@@ -30,6 +31,10 @@ export default createPlugin({
         mergePlugins('customInputs', ERRORS.inputAlreadyDefined, setCustomInputs)
       }
       return el(UiProvider, props, children)
+    },
+    renderRouter ({ children }) {
+      if (!routerPortal) return children
+      return el(Portal.Provider, null, children)
     }
   })
 })


### PR DESCRIPTION
## Summary
- add optional `routerPortal` client setting to `startupjs-ui/plugin`
- when enabled, mount an additional `Portal.Provider` inside `renderRouter`
- document the option for apps whose portal content renders router-aware components such as links or navigation actions

## Compatibility
- default behavior is unchanged because `routerPortal` defaults to `false`
- UiProvider still owns the root theme/toast/dialog provider stack

## Checks
- `yarn generate-package-dts`
- `node scripts/check-startupjs-ui-exports.mjs`
- `npx eslint packages/startupjs-ui/plugin.js`
- `git diff --check`
- pre-commit hook passed