### PR TITLE
fix(text-input): normalize web intrinsic sizing

### DIFF
--- a/packages/text-input/index.tsx
+++ b/packages/text-input/index.tsx
@@ -146,6 +146,17 @@ function TextInput ({
     }
   }, [value, resize, numberOfLines, readonly])
 
+  // useDidUpdate(() => {
+  //   if (readonly) return
+  //   if (numberOfLines !== currentNumberOfLines) {
+  //     setCurrentNumberOfLines(numberOfLines)
+  //   }
+  // }, [numberOfLines, currentNumberOfLines, readonly])
+
+  const multiline = useMemo(() => {
+    return resize || numberOfLines > 1
+  }, [resize, numberOfLines])
+
   if (IS_WEB) {
     // repeat mobile behaviour on the web
     // TODO
@@ -164,21 +175,15 @@ function TextInput ({
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useIsomorphicLayoutEffect(() => {
       if (readonly) return
-      // TODO: looks like it's not available anymore on new versions of react-native-web
-      inputRef.current?.setNativeProps?.({ size: '1' })
-    }, [readonly])
+
+      const shrinkToFitProp = multiline ? { cols: '1' } : { size: '1' }
+      inputRef.current?.setNativeProps?.(shrinkToFitProp)
+
+      // setNativeProps is not available in some react-native-web versions.
+      const attribute = multiline ? 'cols' : 'size'
+      inputRef.current?.setAttribute?.(attribute, '1')
+    }, [readonly, multiline])
   }
-
-  // useDidUpdate(() => {
-  //   if (readonly) return
-  //   if (numberOfLines !== currentNumberOfLines) {
-  //     setCurrentNumberOfLines(numberOfLines)
-  //   }
-  // }, [numberOfLines, currentNumberOfLines, readonly])
-
-  const multiline = useMemo(() => {
-    return resize || numberOfLines > 1
-  }, [resize, numberOfLines])
 
   const legacySizing = useMemo(() => {
     const inputHeight = heights[size]


### PR DESCRIPTION
Normalize web intrinsic sizing for `TextInput` in single-line and multiline modes.
On web, React Native Web renders `TextInput` as different DOM elements depending on `multiline`:

```
multiline=false -> <input>
multiline=true  -> <textarea>
```

These elements have different browser intrinsic sizing defaults: `<input>` uses `size`, while `<textarea>` uses `cols`. We already reset single-line inputs with `size=1` to avoid browser default width leaking into shrink-to-fit layouts. This change applies the same normalization to multiline textareas with `cols=1`.

The change also keeps compatibility with React Native Web versions where `setNativeProps` is unavailable by falling back to `setAttribute`.

This makes web `TextInput` sizing depend on wrapper/layout styles instead of browser DOM defaults, matching React Native behavior more closely.