### PR TITLE
fix(file-input): double-send crash guard + uploadBuffer({ collection })

### DIFF
--- a/packages/file-input/constants.js
+++ b/packages/file-input/constants.js
@@ -1,3 +1,9 @@
+export const FILES_PLUGIN_NAME = 'files'
+// collections allowed to hold file metadata docs (uploadBuffer's `collection`
+// option). Overridable through the plugin's isomorphic options:
+//   plugins: { files: { isomorphic: { collections: ['files', 'chatImages'] } } }
+export const DEFAULT_FILE_COLLECTIONS = ['files']
+
 export const GET_FILE_URL = '/api/__ui__/files/get/:fileId'
 export const getFileUrl = (id, extension) => {
   if (!id) throw Error('[ui/FileInput] getFileUrl: fileId is required')

--- a/packages/file-input/files.plugin.js
+++ b/packages/file-input/files.plugin.js
@@ -2,42 +2,53 @@ import { $, BASE_URL, accessControl, serverOnly, Signal, sub } from 'startupjs'
 import { createPlugin } from 'startupjs/registry'
 import busboy from 'busboy'
 import sharp from 'sharp'
-import { DELETE_FILE_URL, GET_FILE_URL, getDeleteFileUrl, getFileUrl, getUploadFileUrl, UPLOAD_SINGLE_FILE_URL } from './constants.js'
+import { DEFAULT_FILE_COLLECTIONS, DELETE_FILE_URL, FILES_PLUGIN_NAME, GET_FILE_URL, getDeleteFileUrl, getFileUrl, getUploadFileUrl, UPLOAD_SINGLE_FILE_URL } from './constants.js'
 import { deleteFile, getDefaultStorageType, getFileBlob, getFileSize } from './providers/index.js'
 import { uploadBuffer } from './server/index.js'
 
 export default createPlugin({
-  name: 'files',
+  name: FILES_PLUGIN_NAME,
   enabled: true,
   order: 'system ui',
-  isomorphic: (_options, plugin) => ({
-    models: models => {
-      return {
-        ...models,
-        files: {
-          default: FilesModel,
-          schema,
-          ...models.files,
-          access: accessControl(models.files?.access || {
-            read: ({ session, docId, doc }) => {
-              const canRead = getServerOptions(plugin).canRead
-              if (!canRead) return true
-              return canRead({
-                source: 'model',
-                session,
-                fileId: docId,
-                file: doc
-              })
-            }
-          }, { force: true })
-        },
-        'files.*': {
-          default: FileModel,
-          ...models['files.*']
+  // collections: allowlist of collections which may hold file metadata docs --
+  // the ONLY collections uploadBuffer's `collection` option accepts. Default
+  // ['files']. If you override it, keep 'files' in the list, otherwise the
+  // built-in upload route (which always writes to 'files') stops working.
+  isomorphic: ({ collections = DEFAULT_FILE_COLLECTIONS } = {}, plugin) => {
+    if (!collections.includes('files')) {
+      console.warn('[ui/files] the `collections` isomorphic option does not include \'files\' -- ' +
+        'the built-in upload route always writes to \'files\' and will error. ' +
+        'Did you mean to APPEND your collection instead of replacing the list?')
+    }
+    return {
+      models: models => {
+        return {
+          ...models,
+          files: {
+            default: FilesModel,
+            schema,
+            ...models.files,
+            access: accessControl(models.files?.access || {
+              read: ({ session, docId, doc }) => {
+                const canRead = getServerOptions(plugin).canRead
+                if (!canRead) return true
+                return canRead({
+                  source: 'model',
+                  session,
+                  fileId: docId,
+                  file: doc
+                })
+              }
+            }, { force: true })
+          },
+          'files.*': {
+            default: FileModel,
+            ...models['files.*']
+          }
         }
       }
     }
-  }),
+  },
   server: (options = {}) => ({
     serverRoutes: expressApp => {
       expressApp.get(GET_FILE_URL, async (req, res) => {

--- a/packages/file-input/files.plugin.js
+++ b/packages/file-input/files.plugin.js
@@ -251,6 +251,14 @@ export default createPlugin({
           stream.on('data', data => buffers.push(data))
 
           stream.on('end', async () => {
+            // a stream 'error' (e.g. sharp rejecting a forged image) may have
+            // already responded (onStreamError sent 400), but the source
+            // busboy stream still fires 'end' — bail before double-sending,
+            // otherwise the res.json below throws ERR_HTTP_HEADERS_SENT and,
+            // being an unhandled async error, crashes the whole server process.
+            // A single forged "image/*" upload with garbage bytes would
+            // otherwise take the server down.
+            if (res.headersSent) return
             let blob = Buffer.concat(buffers)
             meta = { filename, mimeType, encoding, storageType }
             if (!blob) return res.status(500).send('No file was uploaded')

--- a/packages/file-input/server/uploadBuffer.js
+++ b/packages/file-input/server/uploadBuffer.js
@@ -1,16 +1,27 @@
 import { $, sub } from 'startupjs'
+import { getPlugin } from 'startupjs/registry'
 import { deleteFile, getDefaultStorageType, saveFileBlob } from '../providers/index.js'
+import { DEFAULT_FILE_COLLECTIONS, FILES_PLUGIN_NAME } from '../constants.js'
 
 export default async function uploadBuffer (buff, options = {}) {
   // collection: the collection holding the file METADATA doc (blobs go to the
   // storage provider keyed by fileId regardless of collection). Defaults to
   // 'files'; pass a custom collection to keep special-purpose uploads out of
   // the user-facing files listing.
-  // SECURITY: server-side writes bypass access control, so `collection` (like
-  // `meta`) must be a server-chosen constant — NEVER derive it from request
-  // data, or any client could write docs into arbitrary collections. The
-  // built-in upload route always writes to 'files'.
+  // SECURITY: server-side writes bypass access control, so `collection` must be
+  // declared in the files plugin's `collections` isomorphic allowlist -- even a
+  // careless passthrough of request data can then only ever reach collections
+  // explicitly registered as file collections. The built-in upload route
+  // always writes to 'files'.
   let { fileId, meta = {}, collection = 'files' } = options
+  const allowedCollections = getAllowedCollections()
+  if (!allowedCollections.includes(collection)) {
+    throw new Error(
+      `[ui/files] uploadBuffer: collection '${collection}' is not registered as a file collection. ` +
+      'Declare it in startupjs.config.js: ' +
+      `plugins: { files: { isomorphic: { collections: [${[...allowedCollections, collection].map(c => `'${c}'`).join(', ')}] } } }`
+    )
+  }
 
   let storageType = meta.storageType
   try {
@@ -68,4 +79,17 @@ export default async function uploadBuffer (buff, options = {}) {
     await $file.set(doc)
   }
   return fileId
+}
+
+// the files plugin's `collections` isomorphic option. Falls back to just
+// ['files'] when the plugin options aren't readable (e.g. registry not
+// initialized in a standalone script) -- strict in the right direction:
+// the default collection keeps working, custom ones require the declared
+// allowlist.
+function getAllowedCollections () {
+  try {
+    const { collections } = getPlugin(FILES_PLUGIN_NAME).optionsByEnv.isomorphic || {}
+    if (Array.isArray(collections)) return collections
+  } catch {}
+  return DEFAULT_FILE_COLLECTIONS
 }

--- a/packages/file-input/server/uploadBuffer.js
+++ b/packages/file-input/server/uploadBuffer.js
@@ -6,6 +6,10 @@ export default async function uploadBuffer (buff, options = {}) {
   // storage provider keyed by fileId regardless of collection). Defaults to
   // 'files'; pass a custom collection to keep special-purpose uploads out of
   // the user-facing files listing.
+  // SECURITY: server-side writes bypass access control, so `collection` (like
+  // `meta`) must be a server-chosen constant — NEVER derive it from request
+  // data, or any client could write docs into arbitrary collections. The
+  // built-in upload route always writes to 'files'.
   let { fileId, meta = {}, collection = 'files' } = options
 
   let storageType = meta.storageType

--- a/packages/file-input/server/uploadBuffer.js
+++ b/packages/file-input/server/uploadBuffer.js
@@ -2,7 +2,11 @@ import { $, sub } from 'startupjs'
 import { deleteFile, getDefaultStorageType, saveFileBlob } from '../providers/index.js'
 
 export default async function uploadBuffer (buff, options = {}) {
-  let { fileId, meta = {} } = options
+  // collection: the collection holding the file METADATA doc (blobs go to the
+  // storage provider keyed by fileId regardless of collection). Defaults to
+  // 'files'; pass a custom collection to keep special-purpose uploads out of
+  // the user-facing files listing.
+  let { fileId, meta = {}, collection = 'files' } = options
 
   let storageType = meta.storageType
   try {
@@ -29,9 +33,17 @@ export default async function uploadBuffer (buff, options = {}) {
     for (const key in meta) {
       if (meta[key] == null) delete doc[key]
     }
-    await $.files.addNew(doc)
+    if (collection === 'files') {
+      await $.files.addNew(doc)
+    } else {
+      // custom collections have no FilesModel — add with the same timestamps.
+      // (NOT feature-detected via `$col.addNew`: signals are callable proxies,
+      // so that property is a child signal with typeof 'function' everywhere.)
+      const now = Date.now()
+      await $[collection].add({ createdAt: now, updatedAt: now, ...doc })
+    }
   } else {
-    const $file = await sub($.files[fileId])
+    const $file = await sub($[collection][fileId])
 
     // when changing storageType we should delete the file from the old storageType
     const oldStorageType = $file.storageType.get()


### PR DESCRIPTION
## What

Guards the file-upload `'end'` handler against a double-send that crashes the
whole server process.

## The bug

Uploading a **forged image** (an `image/*` mime type with bytes that aren't a
valid image) makes `sharp` emit an `'error'` event. `onStreamError` correctly
sends a `400` (it already has a `headersSent` guard). But the source busboy
stream still fires `'end'`, so the `'end'` handler runs anyway: it concatenates
the partial buffer, uploads it, and calls `res.json({ fileId })` — with **no**
`headersSent` guard. Because the response was already sent, this throws
`ERR_HTTP_HEADERS_SENT`, and as an unhandled async rejection it **crashes the
entire server process**.

So a single untrusted upload (an attacker POSTing `image/jpeg` with garbage) can
take a public site down. This matters anywhere generated/public UIs allow visitor
uploads.

## The fix

Bail from the `'end'` handler when the response was already sent:

```js
stream.on('end', async () => {
  if (res.headersSent) return
  // ...
})
```

The `onStreamError` path already had this guard; the `'end'` path was missed.

## How it was found

Surfaced in an app's E2E suite: a "garbage bytes with an image mime is rejected
and the server survives" test would pass, then the *next* test failed with
`ECONNREFUSED` — the async `ERR_HTTP_HEADERS_SENT` had killed the server in the
gap. Deterministic once request timing lined the `'error'` up before `'end'`.


---

## Follow-up addition: `uploadBuffer({ collection })`

Programmatic uploads can now store the file **metadata doc** in a collection
other than `files` (blobs still go to the storage provider keyed by `fileId`),
keeping special-purpose uploads out of the user-facing files listing:

```js
await uploadBuffer(buff, { meta, collection: 'chatImages' })
```

Default stays `files` (fully backward-compatible). Custom collections have no
`FilesModel`, so the doc is added with explicit `createdAt`/`updatedAt` instead
of `addNew` — deliberately branched on the collection name, because signals are
callable proxies (`typeof $col.addNew === 'function'` is true for ANY property),
so feature-detecting a model method is impossible.

### `collections` isomorphic allowlist (review round 2)

`collection` is never derived from request data by the built-in route, but as
defense-in-depth it's now also validated against a declared allowlist — the
files plugin's isomorphic `collections` option (default `['files']`):

```js
plugins: { files: { isomorphic: { collections: ['files', 'chatImages'] } } }
```

`uploadBuffer` throws for any undeclared collection (the error names the exact
config to add), so even a careless passthrough of client data into
`uploadBuffer` can only ever reach collections explicitly registered as file
collections. The plugin warns at init if a custom list drops `'files'`, since
the built-in upload route always writes there.
